### PR TITLE
adding_interiminvoice_nobreakdown

### DIFF
--- a/Commusoft-Stage2&Live/src/test/java/lable/Invoice_module.java
+++ b/Commusoft-Stage2&Live/src/test/java/lable/Invoice_module.java
@@ -166,4 +166,20 @@ String jobpage; //="https://app.commusoft.co.uk/customers/customer_list/1726/job
 	    adding_invoice.unitprice_FullBreakdown_ByCategory_Parts1("789.05");
 	    adding_invoice.save_invoice();
     }
+	@Test(priority=8)
+	public void adding_interiminvoice_nobreakdown() throws InterruptedException
+	{
+		driver.get(jobpage);
+	    Invoice adding_invoice =new Invoice(driver);
+	    adding_invoice.InvoiceTab();
+	    adding_invoice.addinvoice();
+	    adding_invoice.Interim_invoice();
+	    adding_invoice.invoice_description();
+	    adding_invoice.invoice_notes1("No breakdown additional invoice");
+	    //adding_invoice.customerreference("No breakdown");
+	    adding_invoice.invoice_Category();
+	    adding_invoice.invoice_UserGroup();
+	    adding_invoice.sub_total("800.96");
+	    adding_invoice.save_invoice();
+	}
   }


### PR DESCRIPTION
Creating interim invoice with no breakdown by validating all the fields with valid test data's

https://commusoft.atlassian.net/browse/QA-107

![image](https://user-images.githubusercontent.com/80504112/162198207-daa4cd64-f91e-42c5-afa0-54f63b14f338.png)
